### PR TITLE
Fix AttributeError in extract_first_name function

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,6 @@
 def extract_first_name(full_name):
+    # Ensure the full name is a string before splitting
+    full_name = str(full_name)
     # Split the full name into words using whitespace as the separator
     name_parts = full_name.split()
 
@@ -8,7 +10,7 @@ def extract_first_name(full_name):
         first_name = name_parts[0]
         return first_name
     else:
-        # If there are no words, return an empty string
+        # If there are no words return an empty string
         return ""
 
 


### PR DESCRIPTION
The AttributeError was caused by a type mismatch: the extract_first_name function expected a string input, but received an integer. This error was fixed by converting the 'full_name' parameter to a string before attempting to use the 'split' method, which is only available on string objects. This change ensures that regardless of the input type, the function will not trigger a type-related error and will always return a string, which either contains the first name (if it can be extracted) or is empty.